### PR TITLE
Fix internal-link breakage/404s

### DIFF
--- a/_plugins/baseurl_links.rb
+++ b/_plugins/baseurl_links.rb
@@ -1,0 +1,20 @@
+# Prepend site.baseurl to absolute internal links in rendered HTML.
+#
+# Links in Markdown sources use root-relative paths like /ideas/foo/.
+# When the site is served from a subdirectory (baseurl: /csswg-wiki),
+# these need to become /csswg-wiki/ideas/foo/ in the final HTML.
+# When baseurl is empty (custom domain), this is a no-op.
+
+Jekyll::Hooks.register [:pages, :documents], :post_render do |item|
+  next if item.output_ext != ".html"
+
+  baseurl = item.site.config["baseurl"].to_s
+  next if baseurl.empty?
+
+  prefix = Regexp.escape(baseurl.delete_prefix("/"))
+
+  item.output = item.output.gsub(
+    /((?:href|src)=")\/(?!#{prefix}\/|\/)/,
+    "\\1#{baseurl}/"
+  )
+end


### PR DESCRIPTION
## Summary

**Problem:** All internal links are broken — 404s.

**Cause:** Internal links in our Markdown sources use root-relative paths like `/ideas/print-backgrounds/`). When served from `https://w3c.github.io/csswg-wiki/`, those cause the 404s — because the actual path the HTTP server sees needs to be `/csswg-wiki/ideas/print-backgrounds/`.

**Fix:** This change adds a Jekyll build-time plugin that prepends `site.baseurl` to absolute `href` and `src` attributes in the rendered HTML output. So:

- No changes to Markdown sources needed
- No hardcoded `/csswg-wiki` prefix anywhere — uses whatever `baseurl` is set to in `_config.yml`
- Skips already-prefixed paths, external URLs, protocol-relative URLs, and anchor links
- When `baseurl` is empty (as it will be once we flip on the `wiki.csswg.org` custom domain), the plugin’s a no-op

Fixes https://github.com/w3c/csswg-wiki/issues/4