### PR TITLE
Update api.csswg.org/bikeshed references to spec-generator

### DIFF
--- a/spec/css3-ui/index.md
+++ b/spec/css3-ui/index.md
@@ -41,7 +41,7 @@ General steps in rough order:
   - https://www.w3.org/wiki/CSS3-UI
 - Make spec edits for resolved issues, then move them to https://www.w3.org/wiki/CSS3-UI
   - edit /dvcs.w3.org/csswg/css-ui/Overview.bs
-  - use https://api.csswg.org/bikeshed/ per [instructions](https://wiki.csswg.org/tools/bikeshed#using-the-web-form) to generate spec view HTML
+  - use https://www.w3.org/publications/spec-generator/ per [instructions](https://wiki.csswg.org/tools/bikeshed#using-the-web-form) to generate spec view HTML
   - “Save Page as…” “Web page, HTML only” Overview.html
 
 - For Tantek: process/do all of https://wiki.mozilla.org/Tantek-Mozilla-Projects#CSS3_UI tasks (including moving them here as issues if possible)

--- a/tools/bikeshed/index.md
+++ b/tools/bikeshed/index.md
@@ -8,7 +8,7 @@ Bikeshed is a spec preprocessor, allowing you to write specs in a much more conv
 
 [Bikeshed is maintained on GitHub](https://github.com/tabatkins/bikeshed), and the documentation there describes the full suite of features, which are very useful.
 
-Bikeshed can be easily installed and run locally (requiring no network access unless you're updating the processor or its databases), or accessed as a CGI without any installation at all: https://api.csswg.org/bikeshed/
+Bikeshed can be easily installed and run locally (requiring no network access unless you're updating the processor or its databases), or accessed as a CGI without any installation at all: https://www.w3.org/publications/spec-generator/
 
 See https://github.com/tabatkins/bikeshed#bikeshed-a-spec-preprocessor for more details.
 
@@ -49,14 +49,14 @@ Further instructions and tips can be found in the [Bikeshed docs](https://speced
 If you're on a system with [curl](http://curl.haxx.se/) on it, just save the following line to a file somewhere in your executable path:
 
 ```
-curl https://api.csswg.org/bikeshed/ -F file=@Overview.bs -F force=1 > Overview.html
+curl https://www.w3.org/publications/spec-generator/ -F type=bikeshed-spec -F file=@Overview.bs -F die-on=nothing > Overview.html
 ```
 
 Mark the file as executable, then just run it from within the folder of the spec you're working on.  It will automatically submit `Overview.bs` to the post-processor and save the results to  `Overview.html`.
 
 ### Using the web form
 
-1. Go to: https://api.csswg.org/bikeshed/
+1. Go to: https://www.w3.org/publications/spec-generator/
 1. Click (Choose File) and select the `Overview.bs` file on your local machine that you want to post-process (you should do this when you're ready to check it in).  (Alternately, paste in your source text, or enter the URL of the source file, if it's already been committed.)
 1. Click the (Process) button. You'll get errors and warnings (if any) in one frame, and the processed spec in the other.
 1. Save the page (e.g. in Firefox, choose the "Save Page as..." menu item from the "File" menu, be sure to choose "Web page, HTML only" from the "Save as" popup), name the file `Overview.html` (without the quotes), and save it right next your `Overview.bs` - you'll likely be replacing an older version, that's ok, go ahead and confirm (command-R in the replace dialog).
@@ -69,7 +69,7 @@ If you get an error:
 
 ```
 Error running preprocessor, returned code: 1.
-[1;31mFATAL ERROR:[0m The document requires at least one metadata block.
+FATAL ERROR: The document requires at least one metadata block.
 ```
 
 See https://web.archive.org/web/20160402124506/https://github.com/tabatkins/bikeshed/blob/master/docs/metadata.md for how to create a metadata block for your spec.


### PR DESCRIPTION
This updates `https://api.csswg.org/bikeshed` references to point to https://www.w3.org/publications/spec-generator/ and use appropriate parameters, since the prior API is no longer available.

I also removed some console color codes in an example which added unnecessary noise to the markdown output.