### PR TITLE
IRC channel  and client suggestions

### DIFF
--- a/tools/irc/index.md
+++ b/tools/irc/index.md
@@ -10,7 +10,7 @@ The CSSWG's channels aren't particularly busy except during meetings or events, 
 
 ## Server Info
 
-The main CSSWG channel is used by the CSS Working Group members during meetings and for quick coordination during off-hours. Topic is anything we work on. (Help with using CSS is off-topic.)
+The main CSSWG channel is used by the CSS Working Group members during meetings and for quick coordination during off-hours. Topics include anything we work on. (Help with using CSS is off-topic.)
 
 Server : irc.w3.org
 
@@ -28,7 +28,7 @@ Channel : #css-test
 
 ## IRC Clients
 
-You'll need an IRC client. Opera has one built-in. Mozilla has "Chatzilla", which is part of Seamonkey and available as an add-on for Firefox. Pidgin and Trillian can also do IRC. There's a web interface to IRC called [Mibbit](http://www.mibbit.com/) (type 'irc.w3.org:6665' as the server name). And there are various stand-alone programs you can download.
+You'll need an IRC client. The W3C provides a self-hosted web IRC client [webirc.w3.org](https://webirc.w3.org). See a [suggested list of IRC clients](https://www.w3.org/guide/meetings/irc.html#where-can-i-find-a-client)
 
 ## IRC Commands
 

--- a/tools/irc/index.md
+++ b/tools/irc/index.md
@@ -10,7 +10,7 @@ The CSSWG's channels aren't particularly busy except during meetings or events, 
 
 ## Server Info
 
-The main CSSWG channel is used by the CSS Working Group members during meetings and for quick coordination during off-hours. Topics include anything we work on. (Help with using CSS is off-topic.)
+The CSS Working Group members use the main CSSWG channel for meetings and for quick coordination during off-hours. Topics include anything we work on. (Help with using CSS is off-topic.)
 
 Server : irc.w3.org
 
@@ -28,7 +28,7 @@ Channel : #css-test
 
 ## IRC Clients
 
-You'll need an IRC client. The W3C provides a self-hosted web IRC client [webirc.w3.org](https://webirc.w3.org). See a [suggested list of IRC clients](https://www.w3.org/guide/meetings/irc.html#where-can-i-find-a-client)
+You'll need an IRC client. The W3C provides a self-hosted web IRC client [webirc.w3.org](https://webirc.w3.org). See the [suggested list of IRC clients](https://www.w3.org/guide/meetings/irc.html#where-can-i-find-a-client).
 
 ## IRC Commands
 


### PR DESCRIPTION
Several of the suggestions no longer existed. I was originally going to submit updated links, but since there's a W3C maintained IRC page, linking to that reduces the risk of link rot.